### PR TITLE
Auto resize to image file

### DIFF
--- a/app/src/main/java/net/ichigotake/pyazing/UploadMediaService.java
+++ b/app/src/main/java/net/ichigotake/pyazing/UploadMediaService.java
@@ -70,6 +70,12 @@ public final class UploadMediaService extends Service {
         RequestParams params = new RequestParams();
         UploadMode uploadMode = media.isImage() ? UploadMode.IMAGE : UploadMode.VIDEO;
         params.put(uploadMode.getParameter(), inputStream, filename, media.getMimeType());
+        // TODO: アップロード前に UploadMediaActivity で設定出来るようにする
+        if (media.isImage()) {
+            params.put("auto_resize", 1);
+            params.put("width", 500);
+            params.put("height", 500);
+        }
         AsyncHttpClient client = new AsyncHttpClient();
         Toasts.startUploading(getApplicationContext());
         uploadingNotification.startProgress();


### PR DESCRIPTION
アップロード前にクライアント側で圧縮する方が回線的にもエコだけど、今は動作優先という事で一つ
